### PR TITLE
Add schedule calendar screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
 
     implementation(libs.coil.compose)
     implementation(libs.coil.gif)
+    implementation(libs.calendar.compose)
 
 
     implementation(libs.androidx.work.runtime.ktx)

--- a/app/src/main/java/com/bianca/ai_assistant/ui/bottomNavigation/MainApp.kt
+++ b/app/src/main/java/com/bianca/ai_assistant/ui/bottomNavigation/MainApp.kt
@@ -36,6 +36,7 @@ import com.bianca.ai_assistant.ui.home.HomeScreenWithViewModel
 import com.bianca.ai_assistant.ui.task.TaskDetailScreenWithViewModel
 import com.bianca.ai_assistant.ui.task.TaskListScreenWithViewModel
 import com.bianca.ai_assistant.ui.weather.Forecast5Route
+import com.bianca.ai_assistant.ui.schedule.ScheduleListScreen
 import com.bianca.ai_assistant.viewModel.RecentActivityViewModel
 import com.bianca.ai_assistant.viewModel.article.ArticleViewModel
 import com.bianca.ai_assistant.viewModel.home.HomeViewModel
@@ -152,6 +153,9 @@ fun MainApp(
                     },
                     onNavigateToWeekWeather = { city ->
                         navController.navigate("weatherDetail?city=$city")
+                    },
+                    onNavigateToSchedule = {
+                        navController.navigate("scheduleList")
                     }
                 )
             }
@@ -254,6 +258,11 @@ fun MainApp(
                 Forecast5Route(viewModel = weekWeatherViewModel, city = city ?: "Taipei") {
 
                 }
+            }
+
+            composable("scheduleList") {
+                val events = homeViewModel.homeState.collectAsState().value.events
+                ScheduleListScreen(events = events)
             }
 
 //            composable("recentActivity") {

--- a/app/src/main/java/com/bianca/ai_assistant/ui/home/EventSummaryCard.kt
+++ b/app/src/main/java/com/bianca/ai_assistant/ui/home/EventSummaryCard.kt
@@ -1,5 +1,6 @@
 package com.bianca.ai_assistant.ui.home
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,11 +15,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun EventSummaryCard(events: List<String>) {
+fun EventSummaryCard(events: List<String>, onClick: () -> Unit = {}) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 4.dp),
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .clickable { onClick() },
         shape = RoundedCornerShape(16.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/bianca/ai_assistant/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/bianca/ai_assistant/ui/home/HomeScreen.kt
@@ -53,6 +53,7 @@ fun HomeScreenWithViewModel(
     onAskAI: () -> Unit = {},
     onRecentActivityClick: (RecentActivityDisplay) -> Unit,
     onNavigateToWeekWeather: (String) -> Unit,
+    onNavigateToSchedule: () -> Unit,
 ) {
     val homeData by homeViewModel.homeState.collectAsState()
     val isLoading by homeViewModel.isLoading.collectAsState()
@@ -117,7 +118,8 @@ fun HomeScreenWithViewModel(
             onRecentActivityClick = onRecentActivityClick,
             isLoading = isLoading,
             onRefreshClick = homeViewModel::refreshWeather,
-            onNavigateToWeekWeather = onNavigateToWeekWeather
+            onNavigateToWeekWeather = onNavigateToWeekWeather,
+            onNavigateToSchedule = onNavigateToSchedule
         )
     }
 }
@@ -135,6 +137,7 @@ fun HomeScreen(
     isLoading: Boolean,
     onRefreshClick: () -> Unit = {},
     onNavigateToWeekWeather: (String) -> Unit,
+    onNavigateToSchedule: () -> Unit,
 ) {
     Scaffold(
         topBar = { TopAppBar(title = { Text("今日摘要") }) }
@@ -163,7 +166,8 @@ fun HomeScreen(
             }
             item {
                 EventSummaryCard(
-                    events = homeData.events.map { "${it.time} ${it.title}" }
+                    events = homeData.events.map { "${it.time} ${it.title}" },
+                    onClick = onNavigateToSchedule
                 )
             }
             item {
@@ -338,7 +342,8 @@ fun PreviewHomeScreen() {
             isLoading = false,
             onNavigateToWeekWeather = {
 
-            }
+            },
+            onNavigateToSchedule = {}
         )
     }
 }

--- a/app/src/main/java/com/bianca/ai_assistant/ui/schedule/ScheduleListScreen.kt
+++ b/app/src/main/java/com/bianca/ai_assistant/ui/schedule/ScheduleListScreen.kt
@@ -1,0 +1,44 @@
+package com.bianca.ai_assistant.ui.schedule
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.bianca.ai_assistant.model.EventInfo
+import com.kizitonwose.calendar.compose.Calendar
+import com.kizitonwose.calendar.compose.rememberCalendarState
+import com.kizitonwose.calendar.core.YearMonth
+import com.kizitonwose.calendar.core.daysOfWeek
+
+@Composable
+fun ScheduleListScreen(events: List<EventInfo>) {
+    val currentMonth = YearMonth.now()
+    val state = rememberCalendarState(
+        startMonth = currentMonth.minusMonths(12),
+        endMonth = currentMonth.plusMonths(12),
+        firstVisibleMonth = currentMonth,
+        firstDayOfWeek = daysOfWeek().first()
+    )
+
+    Column {
+        Calendar(state = state, dayContent = { day ->
+            Text(text = day.date.dayOfMonth.toString(), modifier = Modifier.fillMaxWidth())
+        })
+        LazyColumn {
+            items(events) { event ->
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = "${event.time} ${event.title}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier
+                    )
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ navigation = "2.9.0"
 turbine = "1.2.0"
 uiTextGoogleFonts = "1.8.2"
 workRuntimeKtx = "2.10.1"
+calendarCompose = "2.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -69,6 +70,7 @@ androidx-ui-text-google-fonts = { module = "androidx.compose.ui:ui-text-google-f
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coilGif" }
+calendar-compose = { module = "com.kizitonwose.calendar:compose", version.ref = "calendarCompose" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics", version.ref = "firebaseAnalytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebaseCrashlytics" }


### PR DESCRIPTION
## Summary
- integrate Kizitonwose Calendar Compose
- display schedule via `ScheduleListScreen`
- make `EventSummaryCard` clickable and open schedule view
- register `scheduleList` route

## Testing
- `./gradlew test` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_684061fb19a0832584fa057cd7c86cb3