### PR TITLE
Fix navigation to TaskDetail after adding task

### DIFF
--- a/app/src/main/java/com/bianca/ai_assistant/ui/task/TaskListScreen.kt
+++ b/app/src/main/java/com/bianca/ai_assistant/ui/task/TaskListScreen.kt
@@ -134,19 +134,21 @@ fun TaskListScreenWithViewModel(
         onConfirmDialog = { task ->
             val isNew = editingTask == null
             if (isNew) {
-                viewModel.addTask(task) {
-                    recentActivityViewModel.recordTaskEvent("新增", task)
+                viewModel.addTask(task) { saved ->
+                    recentActivityViewModel.recordTaskEvent("新增", saved)
+                    if (saved.dueTime != null && saved.dueTime!! > System.currentTimeMillis()) {
+                        alarmInfo = AlarmRequest(saved.id, saved.dueTime, saved.title)
+                    }
+                    showDialog = false
                 }
-
             } else {
                 viewModel.updateTask(task)
                 recentActivityViewModel.recordTaskEvent("編輯", task)
+                if (task.dueTime != null && task.dueTime!! > System.currentTimeMillis()) {
+                    alarmInfo = AlarmRequest(task.id, task.dueTime, task.title)
+                }
+                showDialog = false
             }
-            if (task.dueTime != null && task.dueTime!! > System.currentTimeMillis()) {
-                alarmInfo =
-                    AlarmRequest(task.id, task.dueTime, task.title, System.currentTimeMillis())
-            }
-            showDialog = false
         }
     )
 


### PR DESCRIPTION
## Summary
- ensure new recent-activity entries use the inserted task ID
- schedule alarms with the saved task data when adding a task

## Testing
- `gradle test` *(fails: plugin resolution requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6840e9590f9c83258b1f167a7eb52871